### PR TITLE
Fix command typo of &

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,9 @@ The green dots in the picture are the matched corresponding points
 1. make sure you have install [PCL_ROS](http://wiki.ros.org/pcl_ros) which is a ROS package used as an interface with PCL
 2. make sure you have publish your points information to rostopic
    run `rostopic list` to see whether you have `/camera/depth/points`
-3. run `cd pcl & rosrun pcl_ros pointcloud_to_pcd input:=/camera/depth/points`
+3. run `cd pcl && rosrun pcl_ros pointcloud_to_pcd input:=/camera/depth/points`
    this will save pcd file to local directory, you can change the name to scene.pcd
-4. run
-  ```./pcl coke_model.pcd scene.pcd -k -c --model_ss 0.02 --scene_ss 0.02 --cg_thresh 5 --cg_size 0.13```
+4. run `./pcl coke_model.pcd scene.pcd -k -c --model_ss 0.02 --scene_ss 0.02 --cg_thresh 5 --cg_size 0.13`
 
 
 ## Goals to achieve  


### PR DESCRIPTION
- In command execution context like this, && means items to the left as well as right of it should be run in sequence in this case.
- A single & means that the preceding commands—to the immediate left of the &—should simply be run in the background.

*Credit: https://stackoverflow.com/a/26770612/4073795*